### PR TITLE
The getBeforeFilters checks array statically

### DIFF
--- a/src/controllers/ApiGuardController.php
+++ b/src/controllers/ApiGuardController.php
@@ -50,7 +50,7 @@ class ApiGuardController extends Controller
             // loop through any before filters and pull out $apiMethods in the controller
 			$beforeFilters = $this->getBeforeFilters();
 			foreach($beforeFilters as $filter) {
-				if(!empty($filter['options'])) {
+				if(!empty($filter['options']['apiMethods'])) {
 					$apiMethods = $filter['options']['apiMethods'];
 				}
 			}


### PR DESCRIPTION
When using more than one before filter on controller, api-guard would die as it was in the second position in the getBeforeFilters array.
Made getBeforeFilters dynamic in Controller so Laravel's Auth or other before filters can be used.
