### PR TITLE
Allow api-response to be updated to any 0.x releases

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.4.0",
         "illuminate/support": "4.2.*",
         "illuminate/database": "*",
-        "ellipsesynergie/api-response": "0.8.0"
+        "ellipsesynergie/api-response": "~0.7"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.4.0",
         "illuminate/support": "4.2.*",
         "illuminate/database": "*",
-        "ellipsesynergie/api-response": "0.7.0"
+        "ellipsesynergie/api-response": "0.8.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
api-response and fractal have been updated a couple times in the last few months. This would allow this package to be kept current, and we can just hope that the next breaking release will be a 1.x release.

The few tests I ran were successful. Hope this helps.