### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "php": ">=5.4.0",
         "illuminate/support": "4.2.*",
         "illuminate/database": "*",
-        "ellipsesynergie/api-response": "~0.7"
+        "ellipsesynergie/api-response": "0.8.*"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Limit dependency to v0.8.* of ellipsesynergie/api-response, since future versions are for Laravel 5, and therefore break with Laravel 4.