### PR TITLE
Updated package to add support for laravel5

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,15 @@ I've been looking for an equivalent for Laravel but did not find any so this is 
 
 ### Required setup
 
-NOTE: Currently, ApiGuard will only work for Laravel 4.2.*.
-
 In the `require` key of `composer.json` file add the following
 
+Laravel 4:
+
     "chrisbjr/api-guard": "0.*"
+
+Laravel 5:
+
+    "chrisbjr/api-guard": "dev-l5"
 
 Run the Composer update comand
 
@@ -39,7 +43,14 @@ In your `config/app.php` add `'Chrisbjr\ApiGuard\ApiGuardServiceProvider'` to th
 
 Now generate the api-guard migration (make sure you have your database configuration set up correctly):
 
+Laravel 4:
+
     $ php artisan migrate --package="chrisbjr/api-guard"
+
+Laravel 5:
+
+    $ php artisan vendor:publish --tag=migrations
+    $ php artisan migrate
 
 It will setup two tables - api_keys and api_logs.
 
@@ -83,9 +94,15 @@ Now, to prevent others from generating API keys through the route above, you can
 
 To create your own configuration file for ApiGuard, run the following command:
 
+Laravel 4:
+
     $ php artisan config:publish chrisbjr/api-guard
 
-The configuration file will be found in `app/config/packages/chrisbjr/api-guard/config.php`. Open this file and change the `generateApiKeyRoute` variable to `false`
+Laravel 5:
+
+    $ php artisan vendor:publish --tag=config
+
+The configuration file will be found in `app/config/packages/chrisbjr/api-guard/config.php` (or `app/config/apiguard.php` for Laravel 5). Open this file and change the `generateApiKeyRoute` variable to `false`
 
     'generateApiKeyRoute' => false
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "4.2.*",
+        "illuminate/support": "5.*",
         "illuminate/database": "*",
         "ellipsesynergie/api-response": "0.8.*"
     },

--- a/src/Chrisbjr/ApiGuard/ApiGuardServiceProvider.php
+++ b/src/Chrisbjr/ApiGuard/ApiGuardServiceProvider.php
@@ -18,11 +18,19 @@ class ApiGuardServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package('chrisbjr/api-guard');
+		// Publish config
+		$this->publishes([
+			__DIR__ . '/../../config/config.php' => config_path('apiguard.php')
+		], 'config');
+
+		// Publish migrations
+		$this->publishes([
+			__DIR__ . '/../../migrations' => base_path('/database/migrations')
+		], 'migrations');
 
         $this->app->register('EllipseSynergie\ApiResponse\Laravel\ResponseServiceProvider');
 
-        require_once __DIR__.'/../../routes.php';
+        require_once __DIR__ . '/../../routes.php';
 	}
 
 	/**

--- a/src/controllers/ApiGuardController.php
+++ b/src/controllers/ApiGuardController.php
@@ -2,7 +2,7 @@
 
 namespace Chrisbjr\ApiGuard;
 
-use Controller;
+use Illuminate\Routing\Controller as BaseController;
 use Route;
 use Request;
 use Config;
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Input;
 use EllipseSynergie\ApiResponse\Laravel\Response;
 use League\Fractal\Manager;
 
-class ApiGuardController extends Controller
+class ApiGuardController extends BaseController
 {
 
     /**
@@ -42,7 +42,7 @@ class ApiGuardController extends Controller
             // Let's instantiate the response class first
             $this->manager = new Manager;
 
-            $this->manager->parseIncludes(Input::get(Config::get('api-guard::includeKeyword', 'include'), array()));
+            $this->manager->parseIncludes(Input::get(Config::get('apiguard.includeKeyword', 'include'), array()));
 
             $this->response = new Response($this->manager);
 
@@ -77,11 +77,11 @@ class ApiGuardController extends Controller
 
             if ($keyAuthentication === true) {
 
-                $key = $request->header(Config::get('api-guard::keyName'));
+                $key = $request->header(Config::get('apiguard.keyName'));
 
                 if (empty($key)) {
                     // Try getting the key from elsewhere
-                    $key = Input::get(Config::get('api-guard::keyName'));
+                    $key = Input::get(Config::get('apiguard.keyName'));
                 }
 
                 if (empty($key)) {
@@ -108,7 +108,7 @@ class ApiGuardController extends Controller
             // Then check the limits of this method
             if (!empty($apiMethods[$method]['limits'])) {
 
-                if (Config::get('api-guard::logging') === false) {
+                if (Config::get('apiguard.logging') === false) {
                     Log::warning("[Chrisbjr/ApiGuard] You specified a limit in the $method method but API logging needs to be enabled in the configuration for this to work.");
                 }
 
@@ -126,7 +126,7 @@ class ApiGuardController extends Controller
                         if (!$this->apiKey->ignore_limits) {
                             // This means the apikey is not ignoring the limits
 
-                            $keyIncrement = (!empty($limits['key']['increment'])) ? $limits['key']['increment'] : Config::get('api-guard::keyLimitIncrement');
+                            $keyIncrement = (!empty($limits['key']['increment'])) ? $limits['key']['increment'] : Config::get('apiguard.keyLimitIncrement');
 
                             $keyIncrementTime = strtotime('-' . $keyIncrement);
 
@@ -160,7 +160,7 @@ class ApiGuardController extends Controller
                             // then we skip this
                         } else {
 
-                            $methodIncrement = (!empty($limits['method']['increment'])) ? $limits['method']['increment'] : Config::get('api-guard::keyLimitIncrement');
+                            $methodIncrement = (!empty($limits['method']['increment'])) ? $limits['method']['increment'] : Config::get('apiguard.keyLimitIncrement');
 
                             $methodIncrementTime = strtotime('-' . $methodIncrement);
 
@@ -185,7 +185,7 @@ class ApiGuardController extends Controller
             }
             // End of cheking limits
 
-            if (Config::get('api-guard::logging') && $keyAuthentication == true) {
+            if (Config::get('apiguard.logging') && $keyAuthentication == true) {
                 // Log this API request
                 $apiLog = new ApiLog;
                 $apiLog->api_key_id = $this->apiKey->id;

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,5 +1,5 @@
 <?php
 
-if (Config::get('api-guard::generateApiKeyRoute')) {
+if (Config::get('apiguard.generateApiKeyRoute')) {
     Route::post('apiguard/api_key', 'Chrisbjr\ApiGuard\ApiKeyController@create');
 }


### PR DESCRIPTION
I updated the package to adapt to laravel5 standards (no more config:publish or migrate:package, so there'll be some changes in this aspect). 

Moved all the laravel5 code to a new branch l5 so developers can easily use ApiGuard for laravel5 with just using the version "dev-l5" in their composer.json.