### PR TITLE
Hotfix

### DIFF
--- a/src/Console/Commands/GenerateApiKeyCommand.php
+++ b/src/Console/Commands/GenerateApiKeyCommand.php
@@ -47,7 +47,7 @@ class GenerateApiKeyCommand extends Command
 
             $apiKey = $apiKeyModel->where('user_id', '=', $userId)->first();
 
-            if ( ! empty($apiKey) || $apiKey->exists) {
+            if ( ! empty($apiKey) || !$apiKey) {
                 $overwrite = $this->ask("This user already has an existing API key. Do you want to overwrite it? [y/n]");
                 if ($overwrite == 'n') {
                     return;

--- a/src/Console/Commands/GenerateApiKeyCommand.php
+++ b/src/Console/Commands/GenerateApiKeyCommand.php
@@ -47,8 +47,8 @@ class GenerateApiKeyCommand extends Command
 
             $apiKey = $apiKeyModel->where('user_id', '=', $userId)->first();
 
-            if ( ! empty($apiKey) || !$apiKey) {
-                $overwrite = $this->ask("This user already has an existing API key. Do you want to overwrite it? [y/n]");
+            if ($apiKey) {
+                $overwrite = $this->ask("This user already has an existing API key. Do you want to create another one? [y/n]");
                 if ($overwrite == 'n') {
                     return;
                 }


### PR DESCRIPTION
I was trying to run this command according to documentation:
```
$ php artisan api-key:generate --user-id=1 --level=10
```
And I got this error.
```
[ErrorException]
  Trying to get property of non-object
```

This pull request fix that error.