### PR TITLE
Log api key even if authentication for method is turned off.

### DIFF
--- a/src/Http/Controllers/ApiGuardController.php
+++ b/src/Http/Controllers/ApiGuardController.php
@@ -87,29 +87,31 @@ class ApiGuardController extends Controller
                 $keyAuthentication = false;
             }
 
+            $key = $request->header(Config::get('apiguard.keyName', 'X-Authorization'));
+
+            if (empty($key)) {
+                // Try getting the key from elsewhere
+                $key = Input::get(Config::get('apiguard.keyName', 'X-Authorization'));
+            }
+
+            $apiKeyModel = App::make(Config::get('apiguard.model', 'Chrisbjr\ApiGuard\Models\ApiKey'));
+
+            if (!empty($key)) {
+                $this->apiKey = $apiKeyModel->getByKey($key);
+            }
+
             if ($keyAuthentication === true) {
-
-                $key = $request->header(Config::get('apiguard.keyName', 'X-Authorization'));
-
-                if (empty($key)) {
-                    // Try getting the key from elsewhere
-                    $key = Input::get(Config::get('apiguard.keyName', 'X-Authorization'));
-                }
 
                 if (empty($key)) {
                     // It's still empty!
                     return $this->response->errorUnauthorized();
                 }
 
-                $apiKeyModel = App::make(Config::get('apiguard.model', 'Chrisbjr\ApiGuard\Models\ApiKey'));
-
                 if ( ! $apiKeyModel instanceof ApiKeyRepository) {
                     Log::error('[Chrisbjr/ApiGuard] You ApiKey model should be an instance of ApiKeyRepository.');
                     $exception = new Exception("You ApiKey model should be an instance of ApiKeyRepository.");
                     throw($exception);
                 }
-
-                $this->apiKey = $apiKeyModel->getByKey($key);
 
                 if (empty($this->apiKey)) {
                     return $this->response->errorUnauthorized();


### PR DESCRIPTION
Let's say that i have a method `show` and it's authentication is set to `false`
```PHP
'show' => [
            'keyAuthentication' => false
        ],
```
And we have a user that is "logged in" (has api key in the header). This fix allows API to log `api_key_id` along with request for this method in data base. If user does not have api key in the header, data `api_key_id` will be `null`.