### PR TITLE
Fix an issue with migrate:refresh

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,6 @@
         "ellipsesynergie/api-response": "0.9.*"
     },
     "autoload": {
-        "classmap": [
-            "database"
-        ],
         "psr-4": {
             "Chrisbjr\\ApiGuard\\": "src"
         }


### PR DESCRIPTION
Composer classmap was causing the migration file to be added twice, see issue #40