### PR TITLE
Allow empty serializedApiMethods and Authenticate User with api-guard middleware

### DIFF
--- a/src/Http/Middleware/ApiGuard.php
+++ b/src/Http/Middleware/ApiGuard.php
@@ -192,7 +192,7 @@ class ApiGuard
 
         // login User
         $headers = apache_request_headers();
-        $api_key = $headers['X-Authorization'];
+        $api_key = $headers[Config::get('apiguard.keyName', 'X-Authorization')];
 
         $user_id = App::make(Config::get('apiguard.model', 'Chrisbjr\ApiGuard\Models\ApiKey'))::where('key', $api_key)
             ->pluck('user_id');

--- a/src/Http/Middleware/ApiGuard.php
+++ b/src/Http/Middleware/ApiGuard.php
@@ -190,6 +190,16 @@ class ApiGuard
           }
       }
 
+        // login User
+        $headers = apache_request_headers();
+        $api_key = $headers['X-Authorization'];
+
+        $user_id = App::make(Config::get('apiguard.model', 'Chrisbjr\ApiGuard\Models\ApiKey'))::where('key', $api_key)
+            ->pluck('user_id');
+        
+        if($user_id !== 0)
+            Auth::loginUsingId($user_id);
+
         return $next($request);
     }
 }

--- a/src/Http/Middleware/ApiGuard.php
+++ b/src/Http/Middleware/ApiGuard.php
@@ -27,11 +27,18 @@ class ApiGuard
      * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next, $serializedApiMethods)
+    public function handle($request, Closure $next, $serializedApiMethods=null)
     {
 
       // Unserialize parameters
-      $apiMethods = unserialize($serializedApiMethods);
+      if($serializedApiMethods !== null)
+      {
+          $apiMethods = unserialize($serializedApiMethods);
+      }
+      else
+      {
+          $apiMethods = [];
+      }
 
       // Let's instantiate the response class first
       $manager = new Manager;


### PR DESCRIPTION
I just was notified of the acceptation of @gholol pull request ( https://github.com/chrisbjr/api-guard/pull/85 ) about api-guard as a laravel middleware.
These are the changes I made from his code.

Basically it just let the possibility to send no "options" and it authenticate the current user so it becomes accessible via Auth::user()

The last thing I would might change on this, is : Adding the possibility to send "$serializedApiMethods" as plain php Array and not as serialized array, let me know if you interrested and I'll commit modifications

You did there great work, hope you'll accept this request 