### PR TITLE
Optionally cache API keys

### DIFF
--- a/config/apiguard.php
+++ b/config/apiguard.php
@@ -99,6 +99,17 @@ return [
         */
         'auth' => Chrisbjr\ApiGuard\Providers\Auth\Illuminate::class
 
-    ]
+    ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Duration the API key should be cached for
+    |--------------------------------------------------------------------------
+    |
+    | This is the number of minutes API keys will be cached for. A value of 0
+    | or less (or not setting the option at all) disables API key caching.
+    |
+    */
+
+    'rememberApiKeyDuration' => 0,
 ];

--- a/src/Http/Middleware/ApiGuard.php
+++ b/src/Http/Middleware/ApiGuard.php
@@ -89,7 +89,7 @@ class ApiGuard
                 throw new Exception("You ApiKey model should be an instance of ApiKeyRepository.");
             }
 
-            $this->apiKey = $apiKeyModel->getByKey($key);
+            $this->apiKey = $apiKeyModel->getByKey($key, config('apiguard.rememberApiKeyDuration', 0));
 
             if (empty($this->apiKey)) {
                 return $response->errorUnauthorized();


### PR DESCRIPTION
The API key lookups are fast, but they can introduce undesired database load in a high volume site. Using the Cache API allows for the load to be pushed somewhere else (e.g. Redis or some other cache store).