### PR TITLE
Make `php artisan api-key:delete` actually delete

### DIFF
--- a/src/Console/Commands/DeleteApiKeyCommand.php
+++ b/src/Console/Commands/DeleteApiKeyCommand.php
@@ -53,8 +53,9 @@ class DeleteApiKeyCommand extends Command
                     return;
                 }
 
-                $this->info("The API key {$key} was deleted.");
+                $apiKey->delete();
 
+                $this->info("The API key {$key} was deleted.");
                 return;
             }
 


### PR DESCRIPTION
The API key passed to the command is found, and its existence is checked, but it is never actually revoked.  Since the model uses SoftDeletes, we can use `$apiKey->delete()` to revoke the key.  Note that this means the command doesn't actually support *deleting* the key unless the model has been replaced in the app config by a model class that doesn't support soft deletes.  We could probably add a flag to specify that the command should use `->forceDelete()` instead, but I haven't opted to do so at this point, erring instead on the side of changing as little as possible.

This PR adds the `->delete()` line so the artisan command will actually revoke the key.