### PR TITLE
Added support for 5.3 middleware issue

### DIFF
--- a/src/Http/Controllers/ApiGuardController.php
+++ b/src/Http/Controllers/ApiGuardController.php
@@ -34,15 +34,15 @@ class ApiGuardController extends Controller
         // Launch middleware
         $this->middleware('apiguard:' . $serializedApiMethods);
 
-        if(getLaravelVersion() >= 5.3){
+        if($this->getLaravelVersion() >= 5.3){
             // After 5.3, we cannot assign the user to the
             // controller until the middleware has completed.
             $this->middleware(function ($request, $next) {
-                attachMiddlewareResult();
+                $this->attachMiddlewareResult();
                 return $next($request);
             });
         }else{
-            attachMiddlewareResult();
+            $this->attachMiddlewareResult();
         }
     }
 

--- a/src/Http/Controllers/ApiGuardController.php
+++ b/src/Http/Controllers/ApiGuardController.php
@@ -50,8 +50,10 @@ class ApiGuardController extends Controller
     /**
      * Attempt to get an authenticated user and build the response object.
      */
-    private function attachMiddlewareResult(){
+    private function attachMiddlewareResult()
+    {
         $this->user = ApiGuardAuth::getUser();
+
         $this->response = ApiResponseBuilder::build();
     }
 
@@ -60,7 +62,8 @@ class ApiGuardController extends Controller
      * currently running laravel application.
      * @return float version e.g: 5.3
      */
-    private function getLaravelVersion(){
+    private function getLaravelVersion()
+    {
         $appVersion = method_exists(app(), 'version') ? app()->version() : app()::VERSION;
         return floatval(substr($appVersion, 0, strpos($appVersion, '.',2)));
     }

--- a/src/Http/Controllers/ApiGuardController.php
+++ b/src/Http/Controllers/ApiGuardController.php
@@ -34,10 +34,35 @@ class ApiGuardController extends Controller
         // Launch middleware
         $this->middleware('apiguard:' . $serializedApiMethods);
 
-        // Attempt to get an authenticated user.
-        $this->user = ApiGuardAuth::getUser();
+        if(getLaravelVersion() >= 5.3){
+            // After 5.3, we cannot assign the user to the
+            // controller until the middleware has completed.
+            $this->middleware(function ($request, $next) {
+                attachMiddlewareResult();
+                return $next($request);
+            });
+        }else{
+            attachMiddlewareResult();
+        }
+    }
 
+
+    /**
+     * Attempt to get an authenticated user and build the response object.
+     */
+    private function attachMiddlewareResult(){
+        $this->user = ApiGuardAuth::getUser();
         $this->response = ApiResponseBuilder::build();
+    }
+
+    /**
+     * Returns the major and minor version of the
+     * currently running laravel application.
+     * @return float version e.g: 5.3
+     */
+    private function getLaravelVersion(){
+        $appVersion = method_exists(app(), 'version') ? app()->version() : app()::VERSION;
+        return floatval(substr($appVersion, 0, strpos($appVersion, '.',2)));
     }
 
 }


### PR DESCRIPTION
As part of Laravel 5.3 middleware is not executed until after controllers are constructed.

Wrapping the assignment of the user within a middleware closures will fix the issue. Since the assignment is done at the end of the middlerware flow.

Laravel upgrade guide:
https://laravel.com/docs/5.3/upgrade#5.3-session-in-constructors

This may fix issues #122 and #113 