### PR TITLE
fixed unauthorizedResponse

### DIFF
--- a/src/Http/Middleware/AuthenticateApiKey.php
+++ b/src/Http/Middleware/AuthenticateApiKey.php
@@ -55,8 +55,8 @@ class AuthenticateApiKey
     {
         return response([
             'error' => [
-                'code'      => '401',
-                'http_code' => 'GEN-UNAUTHORIZED',
+                'code'      => 'GEN-UNAUTHORIZED',
+                'http_code' => 401,
                 'message'   => 'Unauthorized.',
             ],
         ], 401);


### PR DESCRIPTION
during the upgrade from `3.*` to `4.*` the unauthorised response changed from

````
[
    'error' => [
        'code' => 'GEN-UNAUTHORIZED',
        'http_code' => 401,
        'message' => 'Unauthorized'
    ]
]
````

to

````
[
    'error' => [
        'code' => '401',
        'http_code' => 'GEN-UNAUTHORIZED',
        'message' => 'Unauthorized.'
    ]
]
````



However it makes more sense that 401 is the `http_code` not `code` (and also an int)
(The upgrade also added a `.` at the end of the message, which is IMHO a valid change)
